### PR TITLE
fix: Add Flask to requirements

### DIFF
--- a/requirments.txt
+++ b/requirments.txt
@@ -1,3 +1,4 @@
 kollavarsham
 SiderealKundliCraft
 pytz
+Flask


### PR DESCRIPTION
This commit adds Flask to the `requirements.txt` file, which was missed in the previous commit that introduced the web interface.