### PR TITLE
fix: Correct variable name in template

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -18,7 +18,7 @@
             <button type="submit">Generate Calendar</button>
         </form>
 
-        {% if calendar_data %}
+        {% if calendar_data_json %}
         <h2>Calendar for {{ year }}</h2>
         <div class="wheel-container">
             <canvas id="wheelCanvas" width="600" height="600"></canvas>


### PR DESCRIPTION
This commit fixes a bug where the spinning wheel was not being rendered. The `if` condition in the template was checking for `calendar_data`, but the variable passed from the backend was `calendar_data_json`. This has been corrected.